### PR TITLE
Add sample profile for 720p

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,18 @@ This application was created on Linux Debian and requires the following utilitie
 3. **Drag and drop a YouTube video URL into the designated area or use the form. The link should not contain anything else than https://www.youtube.com/watch?v=[ID]**
 4. **The video will be downloaded using `yt-dlp` and saved to your specified directory.**
 
+## Example Profiles
+
+During the first setup, Sujib creates a few sample profiles that you can use as a starting point. Each profile defines the maximum or minimum resolution passed to `yt-dlp`.
+
+| Profile Name | Resolution |
+|--------------|------------|
+| video-highest (4K) | >=1080p |
+| video-1440p (1440P) | up to 1440p |
+| video-1080p (1080P) | up to 1080p |
+| video-720p (720P) | up to 720p |
+| SD | up to 480p |
+
 ## TODO
 
 - Automatic renaming

--- a/functions.php
+++ b/functions.php
@@ -142,7 +142,8 @@ function insertDefaultValues($database) {
         "INSERT OR IGNORE INTO profiles (id, reorder, command_line, name, destination, container, max_res, min_res, audio, video, cache) VALUES (1, '1', '-w --encoding UTF-8 --no-progress', 'video-highest (4K)', '$destination', 'mkv', NULL, '1080', 'bestaudio', 'bestvideo', '--cache-dir $cache_dir')",
         "INSERT OR IGNORE INTO profiles (id, reorder, command_line, name, destination, container, max_res, min_res, audio, video, cache) VALUES (2, '2', '-w --encoding UTF-8 --no-progress', 'video-1080p (1080P)', '$destination', 'mkv', '1080', NULL, 'bestaudio', 'bestvideo', '--cache-dir $cache_dir')",
         "INSERT OR IGNORE INTO profiles (id, reorder, command_line, name, destination, container, max_res, min_res, audio, video, cache) VALUES (3, '3', '-w --encoding UTF-8 --no-progress', 'SD', '$destination', 'mkv', '480', NULL, 'bestaudio', 'bestvideo', '--cache-dir $cache_dir')",
-        "INSERT OR IGNORE INTO profiles (id, reorder, command_line, name, destination, container, max_res, min_res, audio, video, cache) VALUES (4, '4', '-w --encoding UTF-8 --no-progress', 'video-1440p (1440P)', '$destination', 'mkv', '1440', NULL, 'bestaudio', 'bestvideo', '--cache-dir $cache_dir')"
+        "INSERT OR IGNORE INTO profiles (id, reorder, command_line, name, destination, container, max_res, min_res, audio, video, cache) VALUES (4, '4', '-w --encoding UTF-8 --no-progress', 'video-1440p (1440P)', '$destination', 'mkv', '1440', NULL, 'bestaudio', 'bestvideo', '--cache-dir $cache_dir')",
+        "INSERT OR IGNORE INTO profiles (id, reorder, command_line, name, destination, container, max_res, min_res, audio, video, cache) VALUES (5, '5', '-w --encoding UTF-8 --no-progress', 'video-720p (720P)', '$destination', 'mkv', '720', NULL, 'bestaudio', 'bestvideo', '--cache-dir $cache_dir')"
     ];
 
     foreach ($default_profiles as $profile) {

--- a/install.php
+++ b/install.php
@@ -43,7 +43,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
     // Update the profiles table with the selected container and download_dir as destination_dir
     $destination = '%(title)s.%(ext)s';
     $update_profiles_query = [
-        "UPDATE profiles SET container = '$container', destination = '$destination' WHERE id IN (1, 2, 3, 4)"
+        "UPDATE profiles SET container = '$container', destination = '$destination' WHERE id IN (1, 2, 3, 4, 5)"
     ];
     foreach ($update_profiles_query as $query) {
         if (!$database->exec($query)) {


### PR DESCRIPTION
## Summary
- document example download profiles
- add default 720p profile
- handle extra profile during install

## Testing
- `composer install`
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_687acd72b884832f881e9551da5f72a8