### PR TITLE
Fix install redirect

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -166,11 +166,25 @@ main {
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
 }
 
-.install-form h1 {
+/* Center the installation page content */
+.install-main {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  min-height: calc(100vh - 70px);
+}
+
+.install-form {
+  width: 100%;
+}
+
+.install-main h1 {
   font-family: 'Exo', sans-serif;
   color: #0d47a1;
   margin-bottom: 20px;
 }
+
 
 .install-form .form-group {
   margin-bottom: 20px;

--- a/index.php
+++ b/index.php
@@ -4,7 +4,8 @@ ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
 
 // Redirect to install.php if the database does not exist
-if (!file_exists('db.sqlite')) {
+// Use an absolute path to avoid issues with the current working directory
+if (!file_exists(__DIR__ . '/db.sqlite')) {
   header("Location: install.php");
   exit();
 }

--- a/install.php
+++ b/install.php
@@ -20,7 +20,6 @@ set_exception_handler('customException');
 
 $showNav = false;
 require_once 'functions.php';
-require_once 'header.php';
 
 $script_path = realpath(dirname(__FILE__));
 
@@ -55,9 +54,11 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
     header("Location: index.php");
     exit();
 }
+
+require_once 'header.php';
 ?>
 
-<main>
+<main class="install-main">
     <div class="content-blue">
         <h1>Installation</h1>
         <form method="POST" class="install-form">


### PR DESCRIPTION
## Summary
- move POST handling before output in `install.php`
- prevent header errors during install redirect
- use absolute path when checking for `db.sqlite`

## Testing
- `./tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_687afc6e2728832f86feeac0c538d676