### PR TITLE
Fix install redirect

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -166,11 +166,25 @@ main {
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
 }
 
-.install-form h1 {
+/* Center the installation page content */
+.install-main {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  min-height: calc(100vh - 70px);
+}
+
+.install-form {
+  width: 100%;
+}
+
+.install-main h1 {
   font-family: 'Exo', sans-serif;
   color: #0d47a1;
   margin-bottom: 20px;
 }
+
 
 .install-form .form-group {
   margin-bottom: 20px;

--- a/functions.php
+++ b/functions.php
@@ -17,6 +17,11 @@ function handleError($errno, $errstr, $errfile, $errline) {
 set_exception_handler('handleException');
 set_error_handler('handleError');
 
+// Define a constant for the database path so all scripts use the same absolute path
+if (!defined('DB_PATH')) {
+    define('DB_PATH', __DIR__ . '/db.sqlite');
+}
+
 function truncate($string, $length=50, $append="&hellip;") {
     $string = trim($string);
     if (strlen($string) > $length) {
@@ -40,7 +45,7 @@ function extract_video_id($url) {
 }
 
 function initializeDatabase() {
-    $dbPath = __DIR__ . '/db.sqlite';
+    $dbPath = DB_PATH;
 
     if (!file_exists($dbPath)) {
         if (!touch($dbPath)) {
@@ -63,7 +68,7 @@ function initializeDatabase() {
 }
 
 function connectDatabase() {
-    return new SQLite3(__DIR__ . '/db.sqlite');
+    return new SQLite3(DB_PATH);
 }
 
 function createTables($database) {

--- a/header.php
+++ b/header.php
@@ -3,11 +3,12 @@
 <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
     <title>Simple Youtube PHP Downloader</title>
-    <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
-    <link rel="icon" href="favicon.png" type="image/png">
-    <link rel="icon" sizes="32x32" href="favicon-32.png" type="image/png">
-    <link rel="icon" sizes="64x64" href="favicon-64.png" type="image/png">
-    <link rel="icon" sizes="96x96" href="favicon-96.png" type="image/png"> 
+    <?php $basePath = rtrim(dirname($_SERVER['SCRIPT_NAME']), '/').'/'; ?>
+    <link rel="shortcut icon" href="<?php echo $basePath; ?>favicon.ico" type="image/x-icon">
+    <link rel="icon" href="<?php echo $basePath; ?>favicon.png" type="image/png">
+    <link rel="icon" sizes="32x32" href="<?php echo $basePath; ?>favicon-32.png" type="image/png">
+    <link rel="icon" sizes="64x64" href="<?php echo $basePath; ?>favicon-64.png" type="image/png">
+    <link rel="icon" sizes="96x96" href="<?php echo $basePath; ?>favicon-96.png" type="image/png">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.7.2/css/all.css" integrity="sha384-fnmOCqbTlWIlj8LyTjo7mOUStjsKC4pOpQbqyi7RrhN7udi9RwhKkMHpvLbHG9Sr" crossorigin="anonymous">
     <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet"> 
     <link href="https://fonts.googleapis.com/css?family=Exo" rel="stylesheet"> 

--- a/index.php
+++ b/index.php
@@ -3,14 +3,15 @@ ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
 
+require_once 'functions.php';
+
 // Redirect to install.php if the database does not exist
-if (!file_exists('db.sqlite')) {
+if (!file_exists(DB_PATH)) {
   header("Location: install.php");
   exit();
 }
 
 $showNav = true;
-require_once 'functions.php';
 require_once 'header.php';
 
 // Initialize database

--- a/install.php
+++ b/install.php
@@ -20,7 +20,6 @@ set_exception_handler('customException');
 
 $showNav = false;
 require_once 'functions.php';
-require_once 'header.php';
 
 $script_path = realpath(dirname(__FILE__));
 
@@ -55,9 +54,11 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
     header("Location: index.php");
     exit();
 }
+
+require_once 'header.php';
 ?>
 
-<main>
+<main class="install-main">
     <div class="content-blue">
         <h1>Installation</h1>
         <form method="POST" class="install-form">

--- a/options.php
+++ b/options.php
@@ -1,6 +1,7 @@
 <?php
+require_once 'functions.php';
 
-$database = new SQLite3('db.sqlite');
+$database = new SQLite3(DB_PATH);
 
 if (isset($_GET["submit"])) {
     header('Content-Type: application/json');

--- a/profiles.php
+++ b/profiles.php
@@ -1,7 +1,8 @@
 <?php
+require_once 'functions.php';
 
 // Database connection
-$database = new SQLite3('db.sqlite');
+$database = new SQLite3(DB_PATH);
 
 // Get profiles
 if (isset($_GET['get_profiles'])) {


### PR DESCRIPTION
## Summary
- move POST handling before output in `install.php`
- prevent header errors during install redirect
- use absolute path when checking for `db.sqlite`
- use consistent absolute DB path across scripts
- fix favicon path resolution so the icon loads

## Testing
- `composer install`
- `./tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_687afc6e2728832f86feeac0c538d676