### PR TITLE
Add options for download path and rename regex

### DIFF
--- a/download.php
+++ b/download.php
@@ -45,6 +45,7 @@ if (isset($_POST["url"])) {
         echo json_encode(['error' => 'Download directory not set']);
         exit();
     }
+    $options_rename_regex = $options['rename_regex'] ?? '';
 
     $options_subtitles = $options['subtitles'] ?? 0;
     $options_sub_lang = $options['sub_lang'] ?? 'en'; // Default to 'en' if not set
@@ -93,6 +94,17 @@ if (isset($_POST["url"])) {
 
     // Verify the file existence
     if (file_exists($final_filename)) {
+        if (!empty($options_rename_regex)) {
+            $dir = dirname($final_filename);
+            $base = basename($final_filename);
+            $newBase = preg_replace($options_rename_regex, '', $base);
+            if ($newBase && $newBase !== $base) {
+                $newPath = $dir . '/' . $newBase;
+                if (@rename($final_filename, $newPath)) {
+                    $final_filename = $newPath;
+                }
+            }
+        }
         // Fetch media info
         $mediainfo = fetchMediaInfo($final_filename);
         

--- a/index.php
+++ b/index.php
@@ -22,6 +22,8 @@ $options = fetchOptions($database);
 $options_show_last = $options['show_last'] ?? '';
 $options_subtitles = $options['subtitles'] ?? 0;
 $options_sub_lang = $options['sub_lang'] ?? 'en'; // Default to 'en' if not set
+$options_download_dir = $options['download_dir'] ?? '';
+$options_rename_regex = $options['rename_regex'] ?? '';
 
 // Fetch profiles (with error handling)
 function fetchProfiles($database) {
@@ -294,6 +296,14 @@ $(document).ready(function() {
     <p>
       <label style="position: relative;">Subtitle Language (2 letters): </label>
       <input type="text" id="sub_lang" name="sub_lang" maxlength="2" value="<?php echo htmlspecialchars($options_sub_lang ?? ''); ?>">
+    </p>
+    <p>
+      <label style="position: relative;">Download Directory: </label>
+      <input type="text" id="download_dir" name="download_dir" value="<?php echo htmlspecialchars($options_download_dir); ?>">
+    </p>
+    <p>
+      <label style="position: relative;">Rename Regex: </label>
+      <input type="text" id="rename_regex" name="rename_regex" value="<?php echo htmlspecialchars($options_rename_regex); ?>">
     </p>
   </form>
   <p>

--- a/install.php
+++ b/install.php
@@ -26,6 +26,7 @@ $script_path = realpath(dirname(__FILE__));
 if ($_SERVER['REQUEST_METHOD'] == 'POST') {
     $container = $_POST['container'];
     $download_dir = rtrim($_POST['download_dir'], '/'); // Remove trailing slash
+    $rename_regex = isset($_POST['rename_regex']) ? $_POST['rename_regex'] : '';
     $show_last = $_POST['show_last'] === 'none' ? 0 : (int)$_POST['show_last'];
     $subtitles = (int)$_POST['subtitles'];
     $sub_lang = substr($_POST['sub_lang'], 0, 2); // Limit to two characters
@@ -34,7 +35,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
     $database = initializeDatabase();
 
     // Update the options table with the selected values
-    $update_options_query = "UPDATE options SET download_dir = '$download_dir', show_last = $show_last, subtitles = $subtitles, sub_lang = '$sub_lang' WHERE id = 1";
+    $update_options_query = "UPDATE options SET download_dir = '$download_dir', rename_regex = '" . SQLite3::escapeString($rename_regex) . "', show_last = $show_last, subtitles = $subtitles, sub_lang = '$sub_lang' WHERE id = 1";
     if (!$database->exec($update_options_query)) {
         throw new Exception("Error updating options: " . $database->lastErrorMsg());
     }
@@ -72,6 +73,10 @@ require_once 'header.php';
             <div class="form-group">
                 <label for="download_dir">Base Download Directory (must already exist, max 255 characters):</label><br>
                 <input type="text" name="download_dir" id="download_dir" value="<?php echo $script_path; ?>" maxlength="255" required class="form-control">
+            </div><br>
+            <div class="form-group">
+                <label for="rename_regex">Rename Regex (optional):</label><br>
+                <input type="text" name="rename_regex" id="rename_regex" value="" class="form-control">
             </div><br>
             <div class="form-group">
                 <label for="show_last">Number of Last Downloads to Display:</label><br>

--- a/js/script.js
+++ b/js/script.js
@@ -179,11 +179,15 @@ $(document).ready(function() {
         var show_last = $("#show_last").val();
         var subtitles = $("#subtitles").val();
         var sub_lang = $("#sub_lang").val();
+        var download_dir = $("#download_dir").val();
+        var rename_regex = $("#rename_regex").val();
 
         $.post("options.php?submit", {
             showlast: show_last,
             subtitles: subtitles,
-            sub_lang: sub_lang
+            sub_lang: sub_lang,
+            download_dir: download_dir,
+            rename_regex: rename_regex
         }, function(response) {
             if (response.status === 'success') {
                 console.log('Options saved successfully!');

--- a/options.php
+++ b/options.php
@@ -28,6 +28,20 @@ if (isset($_GET["submit"])) {
             $stmt->execute();
         }
 
+        if (isset($_POST["download_dir"])) {
+            $download_dir = rtrim($_POST["download_dir"], '/');
+            $stmt = $database->prepare('UPDATE options SET download_dir = :download_dir');
+            $stmt->bindValue(':download_dir', $download_dir, SQLITE3_TEXT);
+            $stmt->execute();
+        }
+
+        if (isset($_POST["rename_regex"])) {
+            $rename_regex = $_POST["rename_regex"];
+            $stmt = $database->prepare('UPDATE options SET rename_regex = :rename_regex');
+            $stmt->bindValue(':rename_regex', $rename_regex, SQLITE3_TEXT);
+            $stmt->execute();
+        }
+
         // Respond with a success message
         echo json_encode(['status' => 'success']);
     } catch (Exception $e) {


### PR DESCRIPTION
## Summary
- allow configuration of destination directory and rename regex
- persist new options in database and installer
- expose new fields in options form and JS
- apply regex renaming after downloads

## Testing
- `./vendor/bin/phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_687c352b0268832f91757b458bb24296