### PR TITLE
Add multi-rule renaming

### DIFF
--- a/download.php
+++ b/download.php
@@ -96,22 +96,36 @@ if (isset($_POST["url"])) {
     if (file_exists($final_filename)) {
         if (!empty($options_rename_regex)) {
             $dir = dirname($final_filename);
-            $base = basename($final_filename);
+            $currentPath = $final_filename;
+            $rules = preg_split('/\r?\n|;;/', $options_rename_regex);
 
-            $pattern = $options_rename_regex;
-            $replacement = '';
+            foreach ($rules as $rule) {
+                $rule = trim($rule);
+                if ($rule === '') {
+                    continue;
+                }
 
-            if (strpos($options_rename_regex, '||') !== false) {
-                list($pattern, $replacement) = explode('||', $options_rename_regex, 2);
-            }
+                $pattern = $rule;
+                $replacement = '';
 
-            $newBase = preg_replace($pattern, $replacement, $base);
-            if ($newBase && $newBase !== $base) {
-                $newPath = $dir . '/' . $newBase;
-                if (@rename($final_filename, $newPath)) {
-                    $final_filename = $newPath;
+                if (strpos($rule, '||') !== false) {
+                    list($pattern, $replacement) = explode('||', $rule, 2);
+                }
+
+                if (@preg_match($pattern, '') === false) {
+                    continue;
+                }
+
+                $base = basename($currentPath);
+                $newBase = preg_replace($pattern, $replacement, $base);
+                if ($newBase && $newBase !== $base) {
+                    $newPath = $dir . '/' . $newBase;
+                    if (@rename($currentPath, $newPath)) {
+                        $currentPath = $newPath;
+                    }
                 }
             }
+            $final_filename = $currentPath;
         }
         // Fetch media info
         $mediainfo = fetchMediaInfo($final_filename);

--- a/index.php
+++ b/index.php
@@ -303,7 +303,7 @@ $(document).ready(function() {
     </p>
     <p>
       <label style="position: relative;">Rename Regex (pattern||replacement): </label>
-      <input type="text" id="rename_regex" name="rename_regex" value="<?php echo htmlspecialchars($options_rename_regex); ?>" placeholder="/pattern/||replacement">
+      <textarea id="rename_regex" name="rename_regex" rows="2" placeholder="/pattern/||replacement - separate rules with newline or ;;"><?php echo htmlspecialchars($options_rename_regex); ?></textarea>
     </p>
   </form>
   <p>

--- a/install.php
+++ b/install.php
@@ -26,7 +26,10 @@ $script_path = realpath(dirname(__FILE__));
 if ($_SERVER['REQUEST_METHOD'] == 'POST') {
     $container = $_POST['container'];
     $download_dir = rtrim($_POST['download_dir'], '/'); // Remove trailing slash
-    $rename_regex = isset($_POST['rename_regex']) ? $_POST['rename_regex'] : '';
+    $rename_regex = isset($_POST['rename_regex']) ? trim($_POST['rename_regex']) : '';
+    if (strlen($rename_regex) > 1000) {
+        $rename_regex = substr($rename_regex, 0, 1000);
+    }
     $show_last = $_POST['show_last'] === 'none' ? 0 : (int)$_POST['show_last'];
     $subtitles = (int)$_POST['subtitles'];
     $sub_lang = substr($_POST['sub_lang'], 0, 2); // Limit to two characters
@@ -75,8 +78,8 @@ require_once 'header.php';
                 <input type="text" name="download_dir" id="download_dir" value="<?php echo $script_path; ?>" maxlength="255" required class="form-control">
             </div><br>
             <div class="form-group">
-                <label for="rename_regex">Rename Regex (pattern||replacement, optional):</label><br>
-                <input type="text" name="rename_regex" id="rename_regex" value="" class="form-control" placeholder="/pattern/||replacement">
+                <label for="rename_regex">Rename Regex (pattern||replacement pairs, optional):</label><br>
+                <textarea name="rename_regex" id="rename_regex" class="form-control" rows="2" placeholder="/pattern/||replacement - separate rules with newline or ;;"></textarea>
             </div><br>
             <div class="form-group">
                 <label for="show_last">Number of Last Downloads to Display:</label><br>

--- a/options.php
+++ b/options.php
@@ -36,7 +36,10 @@ if (isset($_GET["submit"])) {
         }
 
         if (isset($_POST["rename_regex"])) {
-            $rename_regex = $_POST["rename_regex"];
+            $rename_regex = trim($_POST["rename_regex"]);
+            if (strlen($rename_regex) > 1000) {
+                $rename_regex = substr($rename_regex, 0, 1000);
+            }
             $stmt = $database->prepare('UPDATE options SET rename_regex = :rename_regex');
             $stmt->bindValue(':rename_regex', $rename_regex, SQLITE3_TEXT);
             $stmt->execute();


### PR DESCRIPTION
## Summary
- allow multiple rename rules separated by newline or `;;`
- validate and trim rename pattern input
- update placeholder text for rename rules

## Testing
- `composer install`
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_687c4725c0b8832fae8bdaa1fc56e10e