### PR TITLE
Add rename helper with error handling

### DIFF
--- a/download.php
+++ b/download.php
@@ -95,31 +95,19 @@ if (isset($_POST["url"])) {
     // Verify the file existence
     if (file_exists($final_filename)) {
         if (!empty($options_rename_regex)) {
-            $dir = dirname($final_filename);
+            $dir  = dirname($final_filename);
             $base = basename($final_filename);
 
-            // Support multiple pattern||replacement lines
-            $expressions = preg_split('/\r?\n/', $options_rename_regex);
-            foreach ($expressions as $expr) {
-                $expr = trim($expr);
-                if ($expr === '') continue;
-                $pattern = $expr;
-                $replacement = '';
-
-                if (strpos($expr, '||') !== false) {
-                    list($pattern, $replacement) = explode('||', $expr, 2);
-                }
-
-                $result = preg_replace($pattern, $replacement, $base);
-                if ($result !== null) {
-                    $base = $result;
-                }
-            }
-
-            if ($base !== basename($final_filename)) {
-                $newPath = $dir . '/' . $base;
-                if (@rename($final_filename, $newPath)) {
-                    $final_filename = $newPath;
+            $rename = applyRenameRules($base, $options_rename_regex);
+            if ($rename['error']) {
+                error_log($rename['error']);
+            } else {
+                $base = $rename['filename'];
+                if ($base !== basename($final_filename)) {
+                    $newPath = $dir . '/' . $base;
+                    if (@rename($final_filename, $newPath)) {
+                        $final_filename = $newPath;
+                    }
                 }
             }
         }

--- a/functions.php
+++ b/functions.php
@@ -513,6 +513,32 @@ function saveOptions($database, $download_dir, $rename_regex, $show_last, $subti
     }
 }
 
+function applyRenameRules($filename, $rules) {
+    $expressions = preg_split('/\r?\n/', $rules);
+    $base = $filename;
+    foreach ($expressions as $expr) {
+        $expr = trim($expr);
+        if ($expr === '') {
+            continue;
+        }
+
+        $pattern = $expr;
+        $replacement = '';
+        if (strpos($expr, '||') !== false) {
+            list($pattern, $replacement) = explode('||', $expr, 2);
+        }
+
+        $result = @preg_replace($pattern, $replacement, $base);
+        if ($result === null || preg_last_error() !== PREG_NO_ERROR) {
+            return ['filename' => $filename, 'error' => "Invalid rename regex: $pattern"];
+        }
+
+        $base = $result;
+    }
+
+    return ['filename' => $base, 'error' => null];
+}
+
 function sanitizeShellInput($input) {
     $pattern = '/^[\w\s\-\/\.=:]+$/';
     return preg_match($pattern, $input) ? $input : '';


### PR DESCRIPTION
## Summary
- add `applyRenameRules` helper for regex-based renaming
- use new helper from download process and log invalid patterns

## Testing
- `composer install`
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_687c5d8ff768832fbe6e8437592fbb20