### PR TITLE
Fix deletion refresh issue

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -476,6 +476,7 @@ function generateDeleteForm($filename, $extension, $id) {
                 if (status == \'done\') {
                     $(\'.tabs #\' + delid).remove();
                     $.modal.close();
+                    location.reload();
                 }
             });
         });


### PR DESCRIPTION
## Summary
- refresh UI after deleting a finished download to show updated list

## Testing
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_687c6c3ac2b0832fa738611ae095307a