### PR TITLE
Align reset profiles with installation defaults

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -621,6 +621,8 @@ tbody:before {
   background-color: #fff;
   border-radius: 10px;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  max-height: 90vh;
+  overflow-y: auto;
 }
 
 .profile-item {

--- a/download.php
+++ b/download.php
@@ -54,6 +54,7 @@ if (isset($_POST["url"])) {
     $quality = determineQuality($profile);
 
     $temp_filename = $options['download_dir'] . '/' . $profile['destination'];
+    $dest_path = isset($profile['dest_path']) ? rtrim($profile['dest_path'], '/') : '';
 
     // Final filename
     $get_filename_command = 'yt-dlp ' . escapeshellarg($url) . ' --get-filename -o ' . escapeshellarg($temp_filename) . ' --merge-output-format ' . $profile['container'] . ' ' . $profile_command . ' ' . $profile_cache;
@@ -123,7 +124,17 @@ if (isset($_POST["url"])) {
                 $newPath = $dir . '/' . $base;
                 if (@rename($final_filename, $newPath)) {
                     $final_filename = $newPath;
-               }
+                }
+            }
+        }
+
+        if (!empty($dest_path)) {
+            if (!is_dir($dest_path)) {
+                @mkdir($dest_path, 0777, true);
+            }
+            $moved = rtrim($dest_path, '/') . '/' . basename($final_filename);
+            if (@rename($final_filename, $moved)) {
+                $final_filename = $moved;
             }
         }
         // Fetch media info

--- a/functions.php
+++ b/functions.php
@@ -97,6 +97,7 @@ function createTables($database) {
             command_line TEXT,
             name TEXT,
             destination TEXT,
+            dest_path TEXT,
             container TEXT,
             max_res TEXT,
             min_res TEXT,
@@ -146,6 +147,19 @@ function createTables($database) {
     foreach ($tables as $name => $sql) {
         $database->exec($sql);
     }
+
+    // Ensure dest_path column exists for backward compatibility
+    $columns = $database->query('PRAGMA table_info(profiles)');
+    $destPathExists = false;
+    while ($col = $columns->fetchArray(SQLITE3_ASSOC)) {
+        if ($col['name'] === 'dest_path') {
+            $destPathExists = true;
+            break;
+        }
+    }
+    if (!$destPathExists) {
+        $database->exec('ALTER TABLE profiles ADD COLUMN dest_path TEXT');
+    }
 }
 
 function insertDefaultValues($database) {
@@ -167,10 +181,10 @@ function insertDefaultValues($database) {
         $cache_dir = rtrim(CACHE_DIR, '/') . '/';
         $destination = '%(title)s.%(ext)s';
         $default_profiles = [
-            "INSERT INTO profiles (id, reorder, command_line, name, destination, container, max_res, min_res, audio, video, cache) VALUES (1, '1', '-w --encoding UTF-8 --no-progress', 'video-highest (4K)', '$destination', 'mkv', NULL, '1080', 'bestaudio', 'bestvideo', '--cache-dir $cache_dir')",
-            "INSERT INTO profiles (id, reorder, command_line, name, destination, container, max_res, min_res, audio, video, cache) VALUES (2, '2', '-w --encoding UTF-8 --no-progress', 'video-1080p (1080P)', '$destination', 'mkv', '1080', NULL, 'bestaudio', 'bestvideo', '--cache-dir $cache_dir')",
-            "INSERT INTO profiles (id, reorder, command_line, name, destination, container, max_res, min_res, audio, video, cache) VALUES (4, '4', '-w --encoding UTF-8 --no-progress', 'video-1440p (1440P)', '$destination', 'mkv', '1440', NULL, 'bestaudio', 'bestvideo', '--cache-dir $cache_dir')",
-            "INSERT INTO profiles (id, reorder, command_line, name, destination, container, max_res, min_res, audio, video, cache) VALUES (5, '5', '-w --encoding UTF-8 --no-progress', 'video-720p (720P)', '$destination', 'mkv', '720', NULL, 'bestaudio', 'bestvideo', '--cache-dir $cache_dir')"
+            "INSERT INTO profiles (id, reorder, command_line, name, destination, dest_path, container, max_res, min_res, audio, video, cache) VALUES (1, '1', '-w --encoding UTF-8 --no-progress', 'video-highest (4K)', '$destination', '', 'mkv', NULL, '1080', 'bestaudio', 'bestvideo', '--cache-dir $cache_dir')",
+            "INSERT INTO profiles (id, reorder, command_line, name, destination, dest_path, container, max_res, min_res, audio, video, cache) VALUES (2, '2', '-w --encoding UTF-8 --no-progress', 'video-1080p (1080P)', '$destination', '', 'mkv', '1080', NULL, 'bestaudio', 'bestvideo', '--cache-dir $cache_dir')",
+            "INSERT INTO profiles (id, reorder, command_line, name, destination, dest_path, container, max_res, min_res, audio, video, cache) VALUES (4, '4', '-w --encoding UTF-8 --no-progress', 'video-1440p (1440P)', '$destination', '', 'mkv', '1440', NULL, 'bestaudio', 'bestvideo', '--cache-dir $cache_dir')",
+            "INSERT INTO profiles (id, reorder, command_line, name, destination, dest_path, container, max_res, min_res, audio, video, cache) VALUES (5, '5', '-w --encoding UTF-8 --no-progress', 'video-720p (720P)', '$destination', '', 'mkv', '720', NULL, 'bestaudio', 'bestvideo', '--cache-dir $cache_dir')"
         ];
 
         foreach ($default_profiles as $profile) {

--- a/index.php
+++ b/index.php
@@ -43,6 +43,7 @@ function fetchProfiles($database) {
     return $profiles;
 }
 
+$profiles = [];
 try {
     $profiles = fetchProfiles($database);
 } catch (Exception $e) {
@@ -326,6 +327,10 @@ $(document).ready(function() {
           <input type="hidden" class="profile-input" name="id" value="<?php echo $profile['id']; ?>" />
           <label>Profile Name:</label>
           <input type="text" class="profile-name-input" name="name" maxlength="45" value="<?php echo isset($profile['name']) ? htmlspecialchars($profile['name']) : ''; ?>" />
+          <label>Destination:</label>
+          <input type="text" class="profile-input" name="destination" value="<?php echo htmlspecialchars($profile['destination']); ?>" />
+          <label>Dest. Path:</label>
+          <input type="text" class="profile-input" name="dest_path" value="<?php echo htmlspecialchars($profile['dest_path']); ?>" />
           <label>Container:</label>
           <select class="profile-input" name="container">
             <option value="mkv" <?php if ($profile['container'] == 'mkv') echo 'selected'; ?>>MKV</option>
@@ -344,10 +349,11 @@ $(document).ready(function() {
     <div class="button-container">
       <button type="button" class="btn" id="add_profile">Add Profile</button>
       <button type="button" class="btn" id="reset_profiles">Reset Profiles</button>
+      <button type="button" class="btn" id="save_profiles">Save Profiles</button>
     </div>
   </form>
   <div class="btn-container">
-    <button type="button" class="btn close" rel="modal:close"><i class="fas fa-window-close fa-sm"></i> Close</button>
+    <button type="button" class="btn close" rel="modal:close"><i class="fas fa-window-close fa-sm"></i> Cancel</button>
   </div>
 </div>
 

--- a/js/script.js
+++ b/js/script.js
@@ -203,7 +203,7 @@ $(document).ready(function() {
         saveOptions();
     });
 
-    $(document).on('click', '.btn.close', function(e) {
+    $(document).on('click', '#options-form .btn.close', function(e) {
         e.preventDefault();
         saveOptions();
         $.modal.close();
@@ -229,6 +229,10 @@ $(document).ready(function() {
                         <input type="hidden" class="profile-input" name="id" value="${profile.id}" />
                         <label>Profile Name:</label>
                         <input type="text" class="profile-name-input" name="name" maxlength="45" value="${htmlspecialchars(profile.name ? profile.name : '')}" />
+                        <label>Destination:</label>
+                        <input type="text" class="profile-input" name="destination" value="${htmlspecialchars(profile.destination ? profile.destination : '')}" />
+                        <label>Dest. Path:</label>
+                        <input type="text" class="profile-input" name="dest_path" value="${htmlspecialchars(profile.dest_path ? profile.dest_path : '')}" />
                         <label>Container:</label>
                         <select class="profile-input" name="container">
                             <option value="mkv" ${profile.container == 'mkv' ? 'selected' : ''}>MKV</option>
@@ -261,6 +265,8 @@ $(document).ready(function() {
         $('.profile-item').each(function() {
             var id = $(this).find('input[name="id"]').val();
             var name = $(this).find('input[name="name"]').val();
+            var destination = $(this).find('input[name="destination"]').val();
+            var dest_path = $(this).find('input[name="dest_path"]').val();
             var container = $(this).find('select[name="container"]').val();
             var max_res = $(this).find('input[name="max_res"]').val();
             var min_res = $(this).find('input[name="min_res"]').val();
@@ -276,6 +282,8 @@ $(document).ready(function() {
             profiles.push({
                 id: id,
                 name: name,
+                destination: destination,
+                dest_path: dest_path,
                 container: container,
                 max_res: max_res,
                 min_res: min_res
@@ -349,6 +357,10 @@ $(document).ready(function() {
         }
     });
 
+    $('#save_profiles').click(function() {
+        saveProfiles();
+    });
+
     $(document).on('click', '.delete-profile', function() {
         var id = $(this).data('id');
         if (confirm('Are you sure you want to delete this profile?')) {
@@ -366,11 +378,7 @@ $(document).ready(function() {
         }
     });
 
-    $(document).on('modal:before-close', '#profiles-form', function(event, modal) {
-        saveProfiles(function() {
-            location.reload();
-        });
-    });
+    // Let users close the Manage Profiles modal without automatically saving
 
     $('.drop').each(function() {
         $(this).on('dragenter', function() {

--- a/options.php
+++ b/options.php
@@ -65,6 +65,7 @@ if (isset($_GET['get_profiles'])) {
         echo '<input type="hidden" class="profile-input" name="id" value="'.$profile['id'].'" />';
         echo '<input type="text" class="profile-input" name="name" value="'.htmlspecialchars($profile['name']).'" />';
         echo '<input type="text" class="profile-input" name="destination" value="'.htmlspecialchars($profile['destination']).'" />';
+        echo '<input type="text" class="profile-input" name="dest_path" value="'.htmlspecialchars($profile['dest_path']).'" />';
         echo '<select class="select2 profile-input" name="container">';
         echo '<option value="mkv" '.($profile['container'] == 'mkv' ? 'selected' : '').'>MKV</option>';
         echo '<option value="mp4" '.($profile['container'] == 'mp4' ? 'selected' : '').'>MP4</option>';
@@ -77,7 +78,7 @@ if (isset($_GET['get_profiles'])) {
 }
 
 if (isset($_GET['add_profile'])) {
-    $database->exec("INSERT INTO profiles (reorder, name, destination, container, max_res, min_res) VALUES (0, '', '', 'mkv', '', '')");
+    $database->exec("INSERT INTO profiles (reorder, name, destination, dest_path, container, max_res, min_res) VALUES (0, '', '', '', 'mkv', '', '')");
     exit();
 }
 
@@ -90,13 +91,15 @@ if (isset($_GET['update_profile'])) {
     $id = (int)$_POST['id'];
     $name = $_POST['name'];
     $destination = $_POST['destination'];
+    $dest_path = $_POST['dest_path'];
     $container = $_POST['container'];
     $max_res = $_POST['max_res'];
     $min_res = $_POST['min_res'];
 
-    $stmt = $database->prepare('UPDATE profiles SET name = :name, destination = :destination, container = :container, max_res = :max_res, min_res = :min_res WHERE id = :id');
+    $stmt = $database->prepare('UPDATE profiles SET name = :name, destination = :destination, dest_path = :dest_path, container = :container, max_res = :max_res, min_res = :min_res WHERE id = :id');
     $stmt->bindValue(':name', $name, SQLITE3_TEXT);
     $stmt->bindValue(':destination', $destination, SQLITE3_TEXT);
+    $stmt->bindValue(':dest_path', $dest_path, SQLITE3_TEXT);
     $stmt->bindValue(':container', $container, SQLITE3_TEXT);
     $stmt->bindValue(':max_res', $max_res, SQLITE3_TEXT);
     $stmt->bindValue(':min_res', $min_res, SQLITE3_TEXT);

--- a/profiles.php
+++ b/profiles.php
@@ -20,7 +20,7 @@ if (isset($_GET['get_profiles'])) {
 // Add profile
 if (isset($_POST['add_profile'])) {
     header('Content-Type: application/json');
-    $database->exec("INSERT INTO profiles (reorder, name, destination, container, max_res, min_res) VALUES (0, '', '', 'mkv', '', '')");
+    $database->exec("INSERT INTO profiles (reorder, name, destination, dest_path, container, max_res, min_res) VALUES (0, '', '', '', 'mkv', '', '')");
     echo json_encode(['status' => 'success']);
     exit();
 }
@@ -30,12 +30,14 @@ if (isset($_POST['reset_profiles'])) {
     header('Content-Type: application/json');
     try {
         $database->exec("DELETE FROM profiles");
-        // Add initial profiles
+        // Add initial profiles matching installation defaults
+        $cache_dir = rtrim(CACHE_DIR, '/') . '/';
+        $destination = '%(title)s.%(ext)s';
         $default_profiles = [
-            "INSERT OR IGNORE INTO profiles (id, reorder, command_line, name, destination, container, max_res, min_res, audio, video, cache) VALUES (1, '1', '-w --encoding UTF-8 --no-progress', 'video-highest (4K)', '%(title)s.%(ext)s', 'mkv', NULL, '1080', 'bestaudio', 'bestvideo', '--cache-dir /var/www/html/youtube2/cache/')",
-            "INSERT OR IGNORE INTO profiles (id, reorder, command_line, name, destination, container, max_res, min_res, audio, video, cache) VALUES (2, '2', '-w --encoding UTF-8 --no-progress', 'video-1080p (1080P)', '%(title)s.%(ext)s', 'mkv', '1080', NULL, 'bestaudio', 'bestvideo', '--cache-dir /var/www/html/youtube2/cache/')",
-            "INSERT OR IGNORE INTO profiles (id, reorder, command_line, name, destination, container, max_res, min_res, audio, video, cache) VALUES (3, '3', '-w --encoding UTF-8 --no-progress', 'SD', '%(title)s.%(ext)s', 'mkv', '480', NULL, 'bestaudio', 'bestvideo', '--cache-dir /var/www/html/youtube2/cache/')",
-            "INSERT OR IGNORE INTO profiles (id, reorder, command_line, name, destination, container, max_res, min_res, audio, video, cache) VALUES (4, '4', '-w --encoding UTF-8 --no-progress', 'video-1440p (1440P)', '%(title)s.%(ext)s', 'mkv', '1440', NULL, 'bestaudio', 'bestvideo', '--cache-dir /var/www/html/youtube2/cache/')"
+            "INSERT INTO profiles (id, reorder, command_line, name, destination, dest_path, container, max_res, min_res, audio, video, cache) VALUES (1, '1', '-w --encoding UTF-8 --no-progress', 'video-highest (4K)', '$destination', '', 'mkv', NULL, '1080', 'bestaudio', 'bestvideo', '--cache-dir $cache_dir')",
+            "INSERT INTO profiles (id, reorder, command_line, name, destination, dest_path, container, max_res, min_res, audio, video, cache) VALUES (2, '2', '-w --encoding UTF-8 --no-progress', 'video-1080p (1080P)', '$destination', '', 'mkv', '1080', NULL, 'bestaudio', 'bestvideo', '--cache-dir $cache_dir')",
+            "INSERT INTO profiles (id, reorder, command_line, name, destination, dest_path, container, max_res, min_res, audio, video, cache) VALUES (4, '4', '-w --encoding UTF-8 --no-progress', 'video-1440p (1440P)', '$destination', '', 'mkv', '1440', NULL, 'bestaudio', 'bestvideo', '--cache-dir $cache_dir')",
+            "INSERT INTO profiles (id, reorder, command_line, name, destination, dest_path, container, max_res, min_res, audio, video, cache) VALUES (5, '5', '-w --encoding UTF-8 --no-progress', 'video-720p (720P)', '$destination', '', 'mkv', '720', NULL, 'bestaudio', 'bestvideo', '--cache-dir $cache_dir')"
         ];
         foreach ($default_profiles as $profile) {
             $database->exec($profile);
@@ -56,9 +58,11 @@ if (isset($_POST['update_profiles'])) {
             $id = $database->escapeString($profile['id']);
             $name = $database->escapeString($profile['name']);
             $container = $database->escapeString($profile['container']);
+            $dest_path = $database->escapeString($profile['dest_path']);
+            $destination = $database->escapeString($profile['destination']);
             $max_res = $database->escapeString($profile['max_res']);
             $min_res = $database->escapeString($profile['min_res']);
-            $database->exec("UPDATE profiles SET name='$name', container='$container', max_res='$max_res', min_res='$min_res' WHERE id=$id");
+            $database->exec("UPDATE profiles SET name='$name', destination='$destination', dest_path='$dest_path', container='$container', max_res='$max_res', min_res='$min_res' WHERE id=$id");
         }
         echo json_encode(['status' => 'success']);
     } catch (Exception $e) {

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -31,6 +31,20 @@ class FunctionsTest extends TestCase
         }
     }
 
+    public function testCreateTablesAddsDestPath()
+    {
+        $db = new SQLite3(':memory:');
+        // simulate older schema without dest_path
+        $db->exec("CREATE TABLE profiles (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)");
+        createTables($db);
+        $cols = [];
+        $result = $db->query('PRAGMA table_info(profiles)');
+        while ($row = $result->fetchArray(SQLITE3_ASSOC)) {
+            $cols[] = $row['name'];
+        }
+        $this->assertContains('dest_path', $cols);
+    }
+
     public function testDetermineQualityMin()
     {
         $profile = ['min_res' => '720'];


### PR DESCRIPTION
## Summary
- ensure default profiles reset to the same configuration used during installation
- allow profiles to set a destination path for downloaded files
- move downloads to the destination path if provided
- update rename and delete logic to respect the moved file location
- add destination and dest_path fields to profile editor UI
- add database migration to add dest_path column when missing
- restore explicit 'Save Profiles' button in the profile editor
- handle missing profile data to keep manage-profiles working
- make modal scrollable and allow canceling profile edits

## Testing
- `composer install`
- `./tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_687da47db3b0832f82fece233c86cb37