### PR TITLE
Fix Manage Profiles modal positioning

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -328,7 +328,6 @@ $(document).ready(function() {
     }
 
     $(document).on('modal:open', '#profiles-form', function(event, modal) {
-        $(this).css('display', 'flex');
         loadProfiles();
     });
 


### PR DESCRIPTION
## Summary
- remove custom `display:flex` styling on Manage Profiles modal so jQuery Modal can center it properly

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_687e2fc5f65c832fbc66d5e79602101f