### PR TITLE
Fix Manage Profiles add button visibility

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -768,7 +768,7 @@ ul li:hover .hide {
   display: flex;
   flex-direction: column;
   max-height: 90vh;
-  overflow-y: hidden;
+  overflow-y: auto;
 }
 
 #submit-delete, #submit-rename {

--- a/js/script.js
+++ b/js/script.js
@@ -328,7 +328,6 @@ $(document).ready(function() {
     }
 
     $(document).on('modal:open', '#profiles-form', function(event, modal) {
-        $(this).css('display', 'flex');
         loadProfiles();
     });
 


### PR DESCRIPTION
## Summary
- allow `#profiles_form` to scroll when content exceeds the modal height so control buttons remain accessible

## Testing
- `composer install`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_687e2fc5f65c832fbc66d5e79602101f