### PR TITLE
Add validation for rename

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -337,6 +337,19 @@ function updateFilename($database, $newFilename, $id) {
 
 function handleRenameRequest($id, $newName) {
     $database = connectDatabase();
+
+    // Validate new filename
+    $isValid = preg_match('/^[\\w\- ]+$/u', $newName) &&
+               strpos($newName, '/') === false &&
+               strpos($newName, "\\") === false &&
+               strpos($newName, '..') === false;
+
+    if (!$isValid) {
+        echo 'Invalid filename';
+        $database->close();
+        return;
+    }
+
     $result = fetchRecordById($database, $id);
 
     while ($val = $result->fetchArray()) {


### PR DESCRIPTION
## Summary
- validate new filenames in handleRenameRequest
- test rename validation

## Testing
- `./vendor/bin/phpunit --colors=never`

------
https://chatgpt.com/codex/tasks/task_e_687f9a4cc660832f8db68797f9306a46