### PR TITLE
Refactor rename logic using helper

### DIFF
--- a/download.php
+++ b/download.php
@@ -97,30 +97,10 @@ if (isset($_POST["url"])) {
     if (file_exists($final_filename)) {
         if (!empty($options_rename_regex)) {
             $dir = dirname($final_filename);
-            $base = basename($final_filename);
+            $rename = applyRenameRules(basename($final_filename), $options_rename_regex);
 
-            // Support multiple pattern||replacement lines
-            $expressions = preg_split('/\r?\n/', $options_rename_regex, -1, PREG_SPLIT_NO_EMPTY);
-            foreach ($expressions as $expr) {
-                $expr = rtrim($expr, "\r\n");
-                if ($expr === '') continue;
-
-                $pattern = $expr;
-                $replacement = '';
-
-                if (strpos($expr, '||') !== false) {
-                    list($pattern, $replacement) = explode('||', $expr, 2);
-                }
-
-                $pattern = trim($pattern);
-
-                $result = preg_replace($pattern, $replacement, $base);
-                if ($result !== null) {
-                    $base = $result;
-                }
-            }
-
-            if ($base !== basename($final_filename)) {
+            $base = $rename['filename'];
+            if ($rename['error'] === null && $base !== basename($final_filename)) {
                 $newPath = $dir . '/' . $base;
                 if (@rename($final_filename, $newPath)) {
                     $final_filename = $newPath;

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -83,4 +83,35 @@ class FunctionsTest extends TestCase
         $this->assertStringContainsString('Invalid rename regex', $result['error']);
     }
 
+    public function testApplyRenameRulesMatchesOldLoop()
+    {
+        $filename = 'Another Video.mp4';
+        $rules = "/\\s+/||_\n/Video/||Clip";
+
+        $base = basename($filename);
+        $expressions = preg_split('/\r?\n/', $rules, -1, PREG_SPLIT_NO_EMPTY);
+        foreach ($expressions as $expr) {
+            $expr = rtrim($expr, "\r\n");
+            if ($expr === '') {
+                continue;
+            }
+            $pattern = $expr;
+            $replacement = '';
+            if (strpos($expr, '||') !== false) {
+                list($pattern, $replacement) = explode('||', $expr, 2);
+            }
+            $pattern = trim($pattern);
+            $resultLoop = preg_replace($pattern, $replacement, $base);
+            if ($resultLoop !== null) {
+                $base = $resultLoop;
+            }
+        }
+
+        $expected = $base;
+
+        $result = applyRenameRules('Another Video.mp4', $rules);
+        $this->assertSame($expected, $result['filename']);
+        $this->assertNull($result['error']);
+    }
+
 }


### PR DESCRIPTION
## Summary
- centralize rename logic through applyRenameRules
- update `download.php` to use the new helper and check for errors
- add regression test covering behaviour of the former rename loop

## Testing
- `./vendor/bin/phpunit --colors=never`

------
https://chatgpt.com/codex/tasks/task_e_687f9b05e6cc832f91c96982902581b6