### PR TITLE
Handle download error message

### DIFF
--- a/download.php
+++ b/download.php
@@ -132,7 +132,11 @@ if (isset($_POST["url"])) {
         $response = ['id' => $rowid, 'table' => $table];
         echo json_encode($response);
     } else {
-        echo json_encode(['error' => 'Download failed']);
+        $errorMsg = trim(implode("\n", $output));
+        if ($errorMsg === '') {
+            $errorMsg = 'Download failed';
+        }
+        echo json_encode(['error' => $errorMsg]);
     }
 
     $database->close();

--- a/js/script.js
+++ b/js/script.js
@@ -124,6 +124,13 @@ $(document).ready(function() {
                     if ($(loaderSelector).length > 0) {
                         $.post("download.php", { url: url, id: params }, function(status2) {
                             status2 = jQuery.parseJSON(status2);
+
+                            if (status2.error) {
+                                $(loaderSelector).replaceWith('<div class="text-bloc">' + status2.error + '</div>');
+                                resolve();
+                                return;
+                            }
+
                             $(loaderSelector).replaceWith('<div class="text-bloc">' + status2.table + '</div>');
                             $("#queue ul").find("." + thisdownload).css({
                                 background: '#CDD7E7'


### PR DESCRIPTION
## Summary
- handle `error` property returned from `download.php`
- display the error instead of creating rename/delete buttons
- show full command output when a download fails

## Testing
- `composer install`
- `./tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_687fa170db64832f8880d4a54e2ed709