### PR TITLE
Add error log output

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,20 @@ must explicitly include these characters and enable Unicode mode:
 /[‘’](.+)[‘’]/u||$1
 ```
 
+## Error Log
+
+When the application encounters an error or exception, a short JSON message is returned to the browser.
+The original details are written to a log file defined by the `LOG_FILE` constant in `functions.php`.
+By default this file is `error.log` in the project directory, or `sujib_error.log` in your system's
+temporary folder if the directory is not writable.
+
+Check this file whenever something fails silently. You can change the location
+by defining the `LOG_FILE` constant before including `functions.php`:
+
+```sh
+tail -f path/to/your/logfile
+```
+
 
 ## Example Profiles
 

--- a/functions.php
+++ b/functions.php
@@ -1,14 +1,23 @@
 <?php
 
+// Path for error logging
+if (!defined('LOG_FILE')) {
+    $defaultLog = __DIR__ . '/error.log';
+    if (!is_writable(dirname($defaultLog))) {
+        $defaultLog = sys_get_temp_dir() . '/sujib_error.log';
+    }
+    define('LOG_FILE', $defaultLog);
+}
+
 // Custom error and exception handling functions
 function handleException($exception) {
-    //error_log("Exception: " . $exception->getMessage());
+    error_log('Exception: ' . $exception->getMessage() . PHP_EOL, 3, LOG_FILE);
     echo json_encode(['error' => 'An error occurred. Please try again later.']);
     exit();
 }
 
 function handleError($errno, $errstr, $errfile, $errline) {
-    //error_log("Error: [$errno] $errstr - $errfile:$errline");
+    error_log("Error: [$errno] $errstr - $errfile:$errline" . PHP_EOL, 3, LOG_FILE);
     echo json_encode(['error' => 'An error occurred. Please try again later.']);
     exit();
 }


### PR DESCRIPTION
## Summary
- write uncaught exceptions and errors to an application log file
- define `LOG_FILE` constant for logs
- document the log location in README
- move log constant above handler definitions

## Testing
- `composer install`
- `./tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_687fab069c3c832fa421d59e95686253