### PR TITLE
Add error log output

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,19 @@ must explicitly include these characters and enable Unicode mode:
 /[‘’](.+)[‘’]/u||$1
 ```
 
+## Error Log
+
+When the application encounters an error or exception, it returns a short JSON message to the browser and writes the full details to a file defined by the `LOG_FILE` constant in `functions.php`.
+By default this file is `error.log` located in the same directory as the application code. If that directory cannot be written, the handler falls back to `sujib_error.log` inside your system's temporary folder.
+The file is created automatically if it does not exist.
+
+Check this file whenever something fails silently. You can change the location
+by defining the `LOG_FILE` constant before including `functions.php`:
+
+```sh
+tail -f path/to/your/logfile
+```
+
 
 ## Example Profiles
 

--- a/functions.php
+++ b/functions.php
@@ -1,14 +1,37 @@
 <?php
 
+// Path for error logging
+if (!defined('LOG_FILE')) {
+    $defaultDir = __DIR__;
+    $logPath = $defaultDir . '/error.log';
+
+    if (!is_writable($defaultDir) || (file_exists($logPath) && !is_writable($logPath))) {
+        $logPath = sys_get_temp_dir() . '/sujib_error.log';
+    }
+
+    define('LOG_FILE', $logPath);
+
+    if (!file_exists(LOG_FILE)) {
+        @touch(LOG_FILE);
+        @chmod(LOG_FILE, 0666);
+    }
+}
+
 // Custom error and exception handling functions
 function handleException($exception) {
-    //error_log("Exception: " . $exception->getMessage());
+    $message = 'Exception: ' . $exception->getMessage();
+    if (!error_log($message . PHP_EOL, 3, LOG_FILE)) {
+        error_log($message);
+    }
     echo json_encode(['error' => 'An error occurred. Please try again later.']);
     exit();
 }
 
 function handleError($errno, $errstr, $errfile, $errline) {
-    //error_log("Error: [$errno] $errstr - $errfile:$errline");
+    $message = "Error: [$errno] $errstr - $errfile:$errline";
+    if (!error_log($message . PHP_EOL, 3, LOG_FILE)) {
+        error_log($message);
+    }
     echo json_encode(['error' => 'An error occurred. Please try again later.']);
     exit();
 }


### PR DESCRIPTION
## Summary
- write uncaught exceptions and errors to an application log file
- define `LOG_FILE` constant for logs
- document the log location in README
- move log constant above handler definitions

## Testing
- `composer install`
- `./tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_687fab069c3c832fa421d59e95686253