### PR TITLE
Avoid heavy copy during download

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,27 @@ must explicitly include these characters and enable Unicode mode:
 /[‘’](.+)[‘’]/u||$1
 ```
 
+## Error Log
+
+When the application encounters an error or exception, it returns a short JSON message to the browser and writes the full details to a file defined by the `LOG_FILE` constant in `functions.php`.
+By default this file is `error.log` located in the same directory as the application code. If that directory cannot be written, the handler falls back to `sujib_error.log` inside your system's temporary folder.
+The file is created automatically if it does not exist.
+
+Check this file whenever something fails silently. You can change the location
+by defining the `LOG_FILE` constant before including `functions.php`:
+
+```sh
+tail -f path/to/your/logfile
+```
+
+Moving the downloaded file can fail if the destination resides on a different
+filesystem or lacks the proper permissions. When that happens the application
+logs the rename error and leaves the file in the download directory, so be sure
+to inspect the log to determine the cause.
+
+Warnings such as a failed `rename()` are logged but no longer stop the script,
+so the operation may continue using a fallback copy.
+
 
 ## Example Profiles
 

--- a/download.php
+++ b/download.php
@@ -5,7 +5,7 @@ error_reporting(E_ALL);
 
 const LOCALE = 'fr_FR.UTF-8';
 
-require 'functions.php';
+require_once 'functions.php';
 
 set_time_limit(4000);
 setlocale(LC_ALL, LOCALE);


### PR DESCRIPTION
## Summary
- revert use of `safeMove` in `download.php` so downloads still use `rename`
- keep manual renames using `safeMove` for cross-filesystem moves

## Testing
- `composer install`
- `./tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_687fab069c3c832fa421d59e95686253