### PR TITLE
Avoid heavy copy during download

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,35 @@ must explicitly include these characters and enable Unicode mode:
 /[‘’](.+)[‘’]/u||$1
 ```
 
+## Error Log
+
+When the application encounters an error or exception, it returns a short JSON message to the browser and writes the full details to a file defined by the `LOG_FILE` constant in `functions.php`.
+By default this file is `error.log` located in the same directory as the application code. If that directory cannot be written, the handler falls back to `sujib_error.log` inside your system's temporary folder.
+The file is created automatically if it does not exist.
+
+Check this file whenever something fails silently. You can change the location
+by defining the `LOG_FILE` constant before including `functions.php`:
+
+```sh
+tail -f path/to/your/logfile
+```
+
+Moving the downloaded file can fail if the destination resides on a different
+filesystem or lacks the proper permissions. When that happens the application
+logs the rename error and leaves the file in the download directory, so be sure
+to inspect the log to determine the cause.
+
+Warnings such as a failed `rename()` are logged but no longer stop the script,
+so the operation may continue using a fallback copy.
+
+## Manual Renames
+
+When renaming a downloaded video from the web interface, the new filename can
+include any characters except `/`, `\`, or the sequence `..`. If the name
+contains these invalid characters, the page will display `Invalid filename` and
+no changes will be applied. Any errors while moving the file are written to the
+error log described above.
+
 
 ## Example Profiles
 

--- a/download.php
+++ b/download.php
@@ -5,7 +5,7 @@ error_reporting(E_ALL);
 
 const LOCALE = 'fr_FR.UTF-8';
 
-require 'functions.php';
+require_once 'functions.php';
 
 set_time_limit(4000);
 setlocale(LC_ALL, LOCALE);

--- a/functions.php
+++ b/functions.php
@@ -1,16 +1,69 @@
 <?php
 
+// Path for error logging
+if (!defined('LOG_FILE')) {
+    $defaultDir = __DIR__;
+    $logPath = $defaultDir . '/error.log';
+
+    if (!is_writable($defaultDir) || (file_exists($logPath) && !is_writable($logPath))) {
+        $logPath = sys_get_temp_dir() . '/sujib_error.log';
+    }
+
+    define('LOG_FILE', $logPath);
+
+    if (!file_exists(LOG_FILE)) {
+        @touch(LOG_FILE);
+        @chmod(LOG_FILE, 0666);
+    }
+}
+
 // Custom error and exception handling functions
 function handleException($exception) {
-    //error_log("Exception: " . $exception->getMessage());
+    $message = 'Exception: ' . $exception->getMessage();
+    if (!error_log($message . PHP_EOL, 3, LOG_FILE)) {
+        error_log($message);
+    }
     echo json_encode(['error' => 'An error occurred. Please try again later.']);
     exit();
 }
 
 function handleError($errno, $errstr, $errfile, $errline) {
-    //error_log("Error: [$errno] $errstr - $errfile:$errline");
-    echo json_encode(['error' => 'An error occurred. Please try again later.']);
-    exit();
+    $message = "Error: [$errno] $errstr - $errfile:$errline";
+    if (!error_log($message . PHP_EOL, 3, LOG_FILE)) {
+        error_log($message);
+    }
+
+    // Only stop execution for fatal errors
+    if ($errno & (E_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR)) {
+        echo json_encode(['error' => 'An error occurred. Please try again later.']);
+        exit();
+    }
+
+    // Allow script to continue for warnings and notices
+    return true;
+}
+
+// Attempt to move a file even if the destination is on a different filesystem
+if (!function_exists('safeMove')) {
+function safeMove($source, $dest) {
+    if (@rename($source, $dest)) {
+        return true;
+    }
+
+    $error = error_get_last();
+    if ($error) {
+        error_log('Rename failed: ' . $error['message'] . PHP_EOL, 3, LOG_FILE);
+    }
+
+    if (@copy($source, $dest)) {
+        if (@unlink($source)) {
+            return true;
+        }
+        error_log('Unable to remove original file after copy: ' . $source . PHP_EOL, 3, LOG_FILE);
+    }
+
+    return false;
+}
 }
 
 // Set custom error and exception handlers
@@ -339,7 +392,7 @@ function handleRenameRequest($id, $newName) {
     $database = connectDatabase();
 
     // Validate new filename
-    $isValid = preg_match('/^[\\w\- ]+$/u', $newName) &&
+    $isValid = $newName !== '' &&
                strpos($newName, '/') === false &&
                strpos($newName, "\\") === false &&
                strpos($newName, '..') === false;
@@ -360,11 +413,14 @@ function handleRenameRequest($id, $newName) {
         $newFilenameSql = $path . "/" . stripslashes(SQLite3::escapeString($newName)) . "." . $ext;
 
         if (file_exists($val['filename'])) {
-            rename($val['filename'], $newFilename);
-            updateFilename($database, $newFilenameSql, $id);
+            if (safeMove($val['filename'], $newFilename)) {
+                updateFilename($database, $newFilenameSql, $id);
+                echo basename($newFilename);
+            } else {
+                error_log('Failed to rename ' . $val['filename'] . ' to ' . $newFilename . PHP_EOL, 3, LOG_FILE);
+                echo basename($val['filename']);
+            }
         }
-
-        echo basename($newFilename);
     }
 
     $database->close();


### PR DESCRIPTION
## Summary
- revert use of `safeMove` in `download.php` so downloads still use `rename`
- keep manual renames using `safeMove` for cross-filesystem moves
- allow additional characters when renaming and document restrictions

## Testing
- `composer install`
- `./tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_687fab069c3c832fa421d59e95686253